### PR TITLE
Feat 0002 nft stake unlock

### DIFF
--- a/docs/stories/0002-nft-stake-unlock.md
+++ b/docs/stories/0002-nft-stake-unlock.md
@@ -168,11 +168,11 @@ Feature: Unlock NFT
     When I call the unlockNFT function with my NFT's tokenId
     Then an error is thrown with the message "InsuficientFundsSent"
 
-  Scenario: Unlock NFT with invalid staking period
+  Scenario: Unlock NFT with invalid Time
     Given I am a user with an NFT that is staked
     And the staking period is not valid
     When I call the unlockNFT function with my NFT's tokenId
-    Then an error is thrown with the message "InvalidPeriod"
+    Then an error is thrown with the message "NFTPeriodNotReady"
 ```
 
 ### Acceptance Criteria

--- a/test/Staking.t.sol
+++ b/test/Staking.t.sol
@@ -56,7 +56,14 @@ contract StakingTest is Test {
         When I attempt to deploy the contract
         Then an error "NFTAddressCannotBeZero" should be thrown    
      */
-    function test_Constructor_ZeroAddressSanity() public {}
+    function test_Constructor_ZeroAddressSanity() public {
+        // Given I provide an NFT address set to 0
+        address lnftAddr = address(0);
+        // Then an error "NFTAddressCannotBeZero" should be thrown
+        // When I attempt to deploy the contract
+        vm.expectRevert(IStaking.MissingNftAddress.selector);
+        staking = new Staking(lnftAddr, 1, 0.01 ether);
+    }
 
     // Test 1.2: Sanity Checks - Invalid Reward Rate
     // Assertion: Verify the constructor reverts with an invalid (e.g., negative) rewardRate.
@@ -66,7 +73,14 @@ contract StakingTest is Test {
         When I attempt to deploy the contract
         Then an error "InvalidRewardRate" should be thrown    
      */
-    function test_Constructor_InvalidRewardRateSanity() public {}
+    function test_Constructor_InvalidRewardRateSanity() public {
+        lnft = new Lazy721("Lazy NFT", "LAZY", 4, "ipfs://lazyhash/");
+        // Given I set a reward rate less than or equal to 0
+        // When I attempt to deploy the contract
+        // Then an error "InvalidRewardRate" should be thrown
+        vm.expectRevert(IStaking.InvalidRewardRate.selector);
+        staking = new Staking(address(lnft), 0, 0.01 ether);
+    }
 
     // Test 1.3: Constructor Parameters
     /**
@@ -80,7 +94,25 @@ contract StakingTest is Test {
         And the reward rate should be set correctly
         And the fee amount should be set correctly
      */
-    function test_ConstructorSuccess() public {}
+    function test_ConstructorSuccess() public {
+        // Given I provide a valid NFT address
+        Lazy721 nft = new Lazy721("Lazy NFT", "LAZY", 4, "ipfs://lazyhash/");
+        // And I set a reward rate greater than 0
+        uint256 newRewardRate = 1;
+        // And I set a fee amount greater than or equal to 0
+        uint256 newFees = 0.01 ether;
+
+        // When I deploy the contract with these parameters
+        Staking newStaking = new Staking(address(nft), newRewardRate, newFees);
+
+        // Then the contract should be deployed successfully
+        // And the NFT address should be set correctly
+        assert(address(newStaking) != address(0));
+        // And the reward rate should be set correctly
+        assert(newStaking.rewardRate() > 0);
+        // And the fee amount should be set correctly
+        assert(newStaking.fees() > 0);
+    }
 
     // ======================
     // Step 2: lock Function Tests
@@ -96,7 +128,22 @@ contract StakingTest is Test {
         When I try to lock the NFT for staking
         Then a NotYourNFTToken error should be thrown
      */
-    function test_Lock_TokenOwnership() public {}
+    function test_Lock_TokenOwnership() public {
+        // Given I do not own the NFT
+        lnft.safeMint(user1);
+        assertEq(lnft.balanceOf(user1), 1);
+        deal(user1, fees);
+        deal(user2, fees);
+
+        vm.prank(user1);
+        lnft.approve(address(staking), 0);
+        assert(lnft.getApproved(0) == address(staking));
+        // When I try to lock the NFT for staking
+        // Then a NotYourNFTToken error should be thrown
+        vm.prank(user2);
+        vm.expectRevert(IStaking.NotYourNFTToken.selector);
+        staking.lock{value: fees}(0, IStaking.Period.ONE_DAY);
+    }
 
     // Test 2.2: Fee Payment
     // Assertion: Verify sufficient funds are required for the transaction.
@@ -108,7 +155,25 @@ contract StakingTest is Test {
         When I lock the NFT for staking with insufficient fees
         Then an InsuficientFundsSent error should be thrown
     */
-    function test_Lock_FeePayment() public {}
+    function test_Lock_FeePayment() public {
+        // Given I have an NFT
+        lnft.safeMint(user1);
+        assertEq(lnft.balanceOf(user1), 1);
+
+        // And I am the owner of the NFT
+        assertEq(lnft.ownerOf(0), user1);
+
+        // And I have granted the staking contract my NFT allowance        
+        vm.prank(user1);
+        lnft.approve(address(staking), 0);
+        assert(lnft.getApproved(0) == address(staking));
+        // When I lock the NFT for staking with insufficient fees
+        // Then an InsufficientFundsSent error should be thrown
+        vm.prank(user1);
+        vm.expectRevert(IStaking.InsufficientFundsSent.selector);
+        staking.lock(0, IStaking.Period.ONE_DAY);
+
+    }
 
     // Test 2.3: NFT Not Found
     // Assertion: Verify the contract reverts when attempting to Lock a non-existent NFT.
@@ -118,7 +183,15 @@ contract StakingTest is Test {
         When I try to lock the NFT for staking
         Then an InvalidTokenId error should be thrown
      */
-    function test_NFTNotFound() public {}
+    function test_NFTNotFound() public {
+        deal(user1, fees);
+        // Given I do not have an NFT
+        //When I try to lock the NFT for staking
+        //Then an InvalidTokenId error should be thrown
+        vm.prank(user1);
+        vm.expectRevert();
+        staking.lock{value: fees}(0, IStaking.Period.ONE_DAY);
+    }
 
     // Test 2.4: Successful locking
     // Assertion: Verify locking is successfully initiated.
@@ -132,7 +205,30 @@ contract StakingTest is Test {
         Then the NFT should be locked for staking
         And I should be able to view my NFT ownership to staking contract   
      */
-    function test_Lock_Success() public {}
+    function test_Lock_Success() public {
+        // Given I have an NFT
+        lnft.safeMint(user1);
+        assertEq(lnft.balanceOf(user1), 1);
+        // Ensure user1 balance can pay fees
+        deal(user1, fees);
+        // And I am the owner of the NFT
+        assertEq(lnft.ownerOf(0), user1);
+
+        // And I have granted the staking contract my NFT allowance
+        vm.prank(user1);
+        lnft.approve(address(staking), 0);
+        assert(lnft.getApproved(0) == address(staking));
+
+        // When I lock the NFT for staking with a valid period
+        // And I pay the required fees
+        vm.prank(user1);
+        staking.lock{value: fees}(0, IStaking.Period.ONE_DAY);
+        // Then the NFT should be locked for staking
+        (uint256 startHeight, ) = staking.users(user1, 0);
+        assert(startHeight == block.number);
+        // And I should be able to view my NFT ownership to staking contract
+        assertEq(lnft.ownerOf(0), address(staking));
+    }
 
     // Test 2.6: Edge Case - locking Already Started
     // Assertion: Verify the contract reverts when attempting to restart locking for an already locking NFT.
@@ -145,7 +241,28 @@ contract StakingTest is Test {
         When I try to lock the NFT for staking
         Then an NotYourNFTToken error should be thrown    
      */
-    function test_LockingAlreadyStarted() public {}
+    function test_LockingAlreadyStarted() public {
+        // Given I have an NFT that is already staked
+        lnft.safeMint(user1);
+        assertEq(lnft.balanceOf(user1), 1);
+        // Ensure user1 balance can pay fees
+        deal(user1, fees);
+        assertEq(lnft.ownerOf(0), user1);
+        vm.prank(user1);
+        lnft.approve(address(staking), 0);
+        assert(lnft.getApproved(0) == address(staking));
+        vm.prank(user1);
+        staking.lock{value: fees}(0, IStaking.Period.ONE_DAY);
+        // Then the NFT should be locked for staking
+        (uint256 startHeight, ) = staking.users(user1, 0);
+        assert(startHeight == block.number);
+        // And I should be able to view my NFT ownership to staking contract
+        assertEq(lnft.ownerOf(0), address(staking));
+        // When I try to lock the NFT for staking
+        // Then a NotYourNFTToken error should be thrown
+        vm.expectRevert(IStaking.NotYourNFTToken.selector);
+        staking.lock{value: fees}(0, IStaking.Period.ONE_DAY);
+    }
 
     // Test 2.7: Lock - Different Periods
     // Assertion: Verify locking with different periods updates correctly.
@@ -162,7 +279,9 @@ contract StakingTest is Test {
         When I lock the NFT for staking with a negative or zero period
         Then an InvalidPeriod error should be thrown
      */
-    function test_LockDifferentPeriods() public {}
+    function test_LockDifferentPeriods() public {
+       // this cant be done since `Period` is force as a type input with only 3 values.
+    }
 
     // Test 2.8: Unlock - Reward Calculation Correctness
     /**
@@ -172,7 +291,35 @@ contract StakingTest is Test {
         When I check my staking points
         Then my points should be calculated as <expected_points> based on the reward rate    
      */
-    function test_RewardCalculationValidPeriod() public {}
+    function test_RewardCalculationValidPeriod() public {
+        // Given I have an NFT
+        lnft.safeMint(user1);
+        assertEq(lnft.balanceOf(user1), 1);
+        // Ensure user1 balance can pay fees
+        deal(user1, fees);
+        // And I am the owner of the NFT
+        assertEq(lnft.ownerOf(0), user1);
+
+        // And I have granted the staking contract my NFT allowance
+        vm.prank(user1);
+        lnft.approve(address(staking), 0);
+        assert(lnft.getApproved(0) == address(staking));
+
+        // When I lock the NFT for staking with a valid period
+        // And I pay the required fees
+        vm.prank(user1);
+        staking.lock{value: fees}(0, IStaking.Period.ONE_DAY);
+        // Then the NFT should be locked for staking
+        (uint256 startHeight, uint256 endHeight) = staking.users(user1, 0);
+        assert(startHeight == block.number);
+        // And I should be able to view my NFT ownership to staking contract
+        assertEq(lnft.ownerOf(0), address(staking));
+        // Check reward amount transferred
+        uint256 expectedReward = (endHeight - startHeight) *
+            staking.rewardRate();
+
+        assert(staking.rewards(user1) == expectedReward);
+    }
 
     // ======================
     // Step 3: Unlock Functionality


### PR DESCRIPTION
# Pull Request

## Description
impl #2 

## Issues
Solidity smart contract implementation of user store 0001 for staking.

## Proposed solution
<!-- Describe the Tasks need it for fixing the issues in this pull request. -->

- Tasks:
  - [X] Using TDD implement the `unlock` feature for staking contract.

## Checklist

- Checklist:
  - [X]Tests
  - [X]Documentation
  - Coverage 

```text
Ran 4 test suites in 4.43s (4.98s CPU time): 75 tests passed, 0 failed, 0 skipped (75 total tests)
| File                | % Lines         | % Statements    | % Branches     | % Funcs        |
|---------------------|-----------------|-----------------|----------------|----------------|
| script/Deploy.s.sol | 0.00% (0/20)    | 0.00% (0/25)    | 100.00% (0/0)  | 0.00% (0/1)    |
| src/Exchange.sol    | 0.00% (0/3)     | 0.00% (0/3)     | 100.00% (0/0)  | 0.00% (0/3)    |
| src/Lazy20.sol      | 100.00% (1/1)   | 100.00% (1/1)   | 100.00% (0/0)  | 100.00% (1/1)  |
| src/Lazy721.sol     | 84.78% (39/46)  | 87.10% (54/62)  | 50.00% (9/18)  | 84.62% (11/13) |
| src/Staking.sol     | 85.71% (30/35)  | 87.18% (34/39)  | 87.50% (7/8)   | 42.86% (3/7)   |
| Total               | 66.67% (70/105) | 68.46% (89/130) | 61.54% (16/26) | 60.00% (15/25) |

```